### PR TITLE
Do not close Mongo connection after getting shards name

### DIFF
--- a/core/src/main/java/com/mongodb/hadoop/splitter/MongoCollectionSplitter.java
+++ b/core/src/main/java/com/mongodb/hadoop/splitter/MongoCollectionSplitter.java
@@ -90,9 +90,6 @@ public abstract class MongoCollectionSplitter extends MongoSplitter {
             if (cur != null) {
                 cur.close();
             }
-            if (configDB != null) {
-                MongoConfigUtil.close(configDB.getMongo());
-            }
         }
         return shardsMap;
     }


### PR DESCRIPTION
getShardsMap is currently closing the MongoDB connection, which is reused further when looping on all chunks (while (cur.hasNext()) at ShardChunkMongoSplitter.java#93).

This causes the next MongoDB query to fail because connection has been closed.
